### PR TITLE
Nix flake

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,44 @@
+# dvcoolarun/web2pdf nix flake
+
+[Nix](https://nixos.org "Nix") flake for <https://github.com/dvcoolarun/web2pdf>.
+
+## Usage
+
+``` sh
+nix run github:dvcoolarun/web2pdf?dir=nix
+```
+
+The default is python 3.11. However, there are other Python versions available:
+
+- Python 3.8: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python38`
+- Python 3.9: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python39`
+- Python 3.10: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python310`
+- Python 3.11: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python311`
+
+## How to declare it in your flake
+
+Check the latest tag of the definition repository: <https://github.com/dvcoolarun/web2pdf/tags>, and use it instead of the `[version]` placeholder below.
+
+```nix
+{
+  description = "[..]";
+  inputs = rec {
+    [..]
+    dvcoolarun-web2pdf = {
+      [optional follows]
+      url =
+        "github:dvcoolarun/web2pdf/[version]?dir=nix";
+    };
+  };
+  outputs = [..]
+};
+```
+
+If your project depends upon [https://github.com/nixos/nixpkgs](nixpkgs "nixpkgs") and/or [https://github.com/numtide/flake-utils](flake-utils "flake-utils"), you might want to pin them under the `[optional follows]` above.
+
+Use the specific package depending on your system (one of `flake-utils.lib.defaultSystems`) and Python version:
+
+- `#packages.[system].dvcoolarun-web2pdf-python38` 
+- `#packages.[system].dvcoolarun-web2pdf-python39` 
+- `#packages.[system].dvcoolarun-web2pdf-python310` 
+- `#packages.[system].dvcoolarun-web2pdf-python311`

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "v1.0.0",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flit": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixos": [
+          "nixos"
+        ],
+        "trove-classifiers": "trove-classifiers"
+      },
+      "locked": {
+        "dir": "flit",
+        "lastModified": 1707206283,
+        "narHash": "sha256-zpGRdOVVXFsa6sYg5F1UtwhBCCGjB2OXxjTEX1CmmT4=",
+        "owner": "rydnr",
+        "repo": "nix-flakes",
+        "rev": "60dce07728a6ef431d729880e6b2cbd67bb7e5dd",
+        "type": "github"
+      },
+      "original": {
+        "dir": "flit",
+        "owner": "rydnr",
+        "ref": "flit-3.9.0-0",
+        "repo": "nix-flakes",
+        "type": "github"
+      }
+    },
+    "nixos": {
+      "locked": {
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "flit": "flit",
+        "nixos": "nixos"
+      }
+    },
+    "trove-classifiers": {
+      "inputs": {
+        "flake-utils": [
+          "flit",
+          "flake-utils"
+        ],
+        "nixos": [
+          "flit",
+          "nixos"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-Kd+sAwrZXz54ST/jxNGGrfvijrfJGuro4o0oIl7SZKs=",
+        "path": "../trove-classifiers",
+        "type": "path"
+      },
+      "original": {
+        "path": "../trove-classifiers",
+        "type": "path"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,185 @@
+# nix/flake.nix
+#
+# This file packages dvcoolarun/web2pdf as a Nix flake.
+#
+# Copyright (C) 2024-today rydnr's rydnr/web2pdf fork
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+{
+  description = "CLI to convert webpages to PDFs";
+
+  inputs = rec {
+    flake-utils.url = "github:numtide/flake-utils/v1.0.0";
+    flit = {
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.nixos.follows = "nixos";
+      url = "github:rydnr/nix-flakes/flit-3.9.0-0?dir=flit";
+    };
+    nixos.url = "github:NixOS/nixpkgs/23.05";
+  };
+  outputs = inputs:
+    with inputs;
+    let
+      defaultSystems = flake-utils.lib.defaultSystems;
+      supportedSystems = if builtins.elem "armv6l-linux" defaultSystems then
+        defaultSystems
+      else
+        defaultSystems ++ [ "armv6l-linux" ];
+    in flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        owner = "dvcoolarun";
+        repo = "web2pdf";
+        version = "0.0.0";
+        pname = "${owner}-${repo}";
+        description = "CLI to convert webpages to PDFs";
+        homepage = "https://github.com/${owner}/${repo}";
+        maintainers = [ "dvcoolarun" ];
+        nixosVersion = builtins.readFile "${nixos}/.version";
+        nixpkgsRelease =
+          builtins.replaceStrings [ "\n" ] [ "" ] "nixos-${nixosVersion}";
+        pkgs = import nixos { inherit system; };
+        shared = import ./shared.nix;
+        pnameWithUnderscores = builtins.replaceStrings [ "-" ] [ "_" ] pname;
+        dvcoolarun-web2pdf-for = { flit, python }:
+          let
+            pythonVersionParts = builtins.splitVersion python.version;
+            pythonMajorVersion = builtins.head pythonVersionParts;
+            pythonMajorMinorVersion =
+              "${pythonMajorVersion}.${builtins.elemAt pythonVersionParts 1}";
+            pythonPackage = pnameWithUnderscores;
+          in python.pkgs.buildPythonPackage rec {
+            inherit pname version;
+            pyprojectTemplateFile = ./pyprojecttoml.template;
+            pyprojectTemplate = pkgs.substituteAll {
+              authors = builtins.concatStringsSep ","
+                (map (item: ''"${item}"'') maintainers);
+              desc = description;
+              inherit homepage pname pythonMajorMinorVersion version;
+              dominate = python.pkgs.dominate.pname;
+              dominateVersion = python.pkgs.dominate.version;
+              fakeUseragent = python.pkgs.fake-useragent.pname;
+              fakeUseragentVersion = python.pkgs.fake-useragent.version;
+              flit = flit.pname;
+              flitVersion = flit.version;
+              grequests = python.pkgs.grequests.pname;
+              grequestsVersion = python.pkgs.grequests.version;
+              package = pnameWithUnderscores;
+              pillow = python.pkgs.pillow.pname;
+              pillowVersion = python.pkgs.pillow.version;
+              readabilityLxml = python.pkgs.readability-lxml.pname;
+              readabilityLxmlVersion = python.pkgs.readability-lxml.version;
+              rich = python.pkgs.rich.pname;
+              richVersion = python.pkgs.rich.version;
+              src = pyprojectTemplateFile;
+              typer = python.pkgs.typer.pname;
+              typerVersion = python.pkgs.typer.version;
+              validators = python.pkgs.validators.pname;
+              validatorsVersion = python.pkgs.validators.version;
+              weasyprint = python.pkgs.weasyprint.pname;
+              weasyprintVersion = python.pkgs.weasyprint.version;
+            };
+
+            src = pkgs.fetchFromGitHub {
+              inherit owner repo;
+              rev = "main";
+              sha256 = "sha256-XlRPLNSxteFj88gbiWLyPX6FiPrEc2XjCl9xsEO5m8E=";
+            };
+            format = "pyproject";
+
+            doCheck = false;
+
+            nativeBuildInputs = with python.pkgs; [ pip poetry-core ];
+            propagatedBuildInputs = with python.pkgs; [
+              dominate
+              fake-useragent
+              flit
+              grequests
+              pillow
+              readability-lxml
+              rich
+              typer
+              validators
+              weasyprint
+            ];
+
+            meta = with pkgs.lib; {
+              license = licenses.gpl3;
+              inherit description homepage maintainers;
+            };
+
+            pythonImportsCheck = [ pythonPackage ];
+
+            unpackPhase = ''
+              cp -r ${src} .
+              sourceRoot=$(ls | grep -v env-vars)
+              chmod +w $sourceRoot
+              cp ${pyprojectTemplate} $sourceRoot/pyproject.toml
+              mkdir $sourceRoot/${pythonPackage}
+              cp $sourceRoot/main.py $sourceRoot/${pythonPackage}/${pnameWithUnderscores}.py
+            '';
+
+            postInstall = ''
+              mkdir $out/bin
+              cp -r /build/$sourceRoot/${pythonPackage} $out/lib/python${pythonMajorMinorVersion}/site-packages/
+              echo '#!/usr/bin/env sh' > $out/bin/${pnameWithUnderscores}.sh
+              echo "export PYTHONPATH=$PYTHONPATH" >> $out/bin/${pnameWithUnderscores}.sh
+              echo "${python}/bin/python $out/lib/python${pythonMajorMinorVersion}/site-packages/${pythonPackage}/${pnameWithUnderscores}.py \$@" >> $out/bin/${pnameWithUnderscores}.sh
+              chmod +x $out/bin/${pnameWithUnderscores}.sh
+            '';
+
+          };
+      in rec {
+        apps = rec {
+          default = dvcoolarun-web2pdf-default;
+          dvcoolarun-web2pdf-default = dvcoolarun-web2pdf-python311;
+          dvcoolarun-web2pdf-python38 = shared.app-for {
+            entrypoint = "${pnameWithUnderscores}.sh";
+            package = self.packages.${system}.dvcoolarun-web2pdf-python38;
+          };
+          dvcoolarun-web2pdf-python39 = shared.app-for {
+            entrypoint = "${pnameWithUnderscores}.sh";
+            package = self.packages.${system}.dvcoolarun-web2pdf-python39;
+          };
+          dvcoolarun-web2pdf-python310 = shared.app-for {
+            entrypoint = "${pnameWithUnderscores}.sh";
+            package = self.packages.${system}.dvcoolarun-web2pdf-python310;
+          };
+          dvcoolarun-web2pdf-python311 = shared.app-for {
+            entrypoint = "${pnameWithUnderscores}.sh";
+            package = self.packages.${system}.dvcoolarun-web2pdf-python311;
+          };
+        };
+        defaultPackage = packages.default;
+        packages = rec {
+          default = dvcoolarun-web2pdf-default;
+          dvcoolarun-web2pdf-default = dvcoolarun-web2pdf-python311;
+          dvcoolarun-web2pdf-python38 = dvcoolarun-web2pdf-for {
+            flit = flit.packages.${system}.flit-python38;
+            python = pkgs.python38;
+          };
+          dvcoolarun-web2pdf-python39 = dvcoolarun-web2pdf-for {
+            flit = flit.packages.${system}.flit-python39;
+            python = pkgs.python39;
+          };
+          dvcoolarun-web2pdf-python310 = dvcoolarun-web2pdf-for {
+            flit = flit.packages.${system}.flit-python310;
+            python = pkgs.python310;
+          };
+          dvcoolarun-web2pdf-python311 = dvcoolarun-web2pdf-for {
+            flit = flit.packages.${system}.flit-python311;
+            python = pkgs.python311;
+          };
+        };
+      });
+}

--- a/nix/pyprojecttoml.template
+++ b/nix/pyprojecttoml.template
@@ -1,0 +1,43 @@
+# nix/pyprojecttoml.template
+#
+# This file is the template for dvcoolarun/web2pdf's pyproject.toml
+#
+# Copyright (C) 2024-today rydnr's rydnr/web2pdf fork
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+[tool.poetry]
+name = "@pname@"
+version = "@version@"
+description = "@desc@"
+authors = [ @authors@ ]
+readme = "README.md"
+homepage = "@homepage@"
+packages = [{include = "@package@"}]
+
+[tool.poetry.dependencies]
+@dominate@ = "^@dominateVersion@"
+@fakeUseragent@ = "^@fakeUseragentVersion@"
+@flit@ = "^@flitVersion@"
+@grequests@ = "^@grequestsVersion@"
+@pillow@ = "^@pillowVersion@"
+python = "^@pythonMajorMinorVersion@"
+@readabilityLxml@ = "^@readabilityLxmlVersion@"
+@rich@ = "^@richVersion@"
+@typer@ = "^@typerVersion@"
+@validators@ = "^@validatorsVersion@"
+@weasyprint@ = "^@weasyprintVersion@"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -1,0 +1,28 @@
+rec {
+  shellHook-for = { package, python, nixpkgsRelease }: ''
+    export PNAME="${package.pname}";
+    export PVERSION="${package.version}";
+    export PYVERSION="${python.name}";
+    export NIXPKGSRELEASE="${nixpkgsRelease}";
+    export PS1="\033[37m[\[\033[01;33m\]\$PNAME-\$PVERSION\033[01;37m|\033[01;32m\]\$PYVERSION\]\033[37m|\[\033[00m\]\[\033[01;34m\]\W\033[37m]\033[31m\$\[\033[00m\] ";
+    echo;
+    echo -e "        _           \033[34m__ _       _\033[0m";
+    echo -e "       (_)         \033[34m/ _| |     | |\033[0m       GPLv3";
+    echo -e "  \033[32m_ __  ___  __\033[37m   \033[34m| |_| | __ _| | _____  ___\033[0m";
+    echo -e " \033[32m| '_ \\| \\ \\/ /   \033[34m|  _| |/ _\` | |/ / _ \\/ __| \\033[32mhttps://github.com/nixos/nixpkgs/$NIXPKGSRELEASE\033[0m";
+    echo -e " \033[32m| | | | |>  < \033[2m\033[46m   \033[0m\033[34m| | | | (_| |   <  __/\\__ \\ \033[36mhttps://github.com/rydnr/nix-flakes\033[0m";
+    echo -e " \033[32m|_| |_|_/_/\\_\   \033[34m|_| |_|\__,_|_|\\_\\___||___/ https://patreon.com/rydnr\033[0m";
+    echo;
+    echo " Thank you for making Nix and rydnr's Nix Flakes your choice, and for your appreciation of free software.";
+    echo;
+  '';
+  devShell-for = { package, python, pkgs, nixpkgsRelease }:
+    pkgs.mkShell {
+      buildInputs = [ package ];
+      shellHook = shellHook-for { inherit package python nixpkgsRelease; };
+    };
+  app-for = { package, entrypoint }: {
+    type = "app";
+    program = "${package}/bin/${entrypoint}";
+  };
+}


### PR DESCRIPTION
This flake allows [Nix](https://nixos.org "Nix") users to run [web2pdf](https://github.com/dvcoolarun/web2pdf) just by executing

`nix run github:dvcoolarun/web2pdf?dir=nix`

The default is python 3.11. However, the user can choose other Python versions:

- Python 3.8: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python38`
- Python 3.9: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python39`
- Python 3.10: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python310`
- Python 3.11: `nix run github:dvcoolarun/web2pdf?dir=nix#dvcoolarun-web2pdf-python311`

The pdf files the tool generates don't include images, so a dependency may be missing.

I had to remove the "readability" dependency since the import `from readability import Document` was trying to get it from `readability`, and not `readability-lxml`.